### PR TITLE
Revert "Force heroku-18 stack"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -133,11 +133,9 @@ CACHE_DIR=$2
 ENV_DIR=$3
 
 # fix STACK variable if unset
-# if [[ -z "${STACK}" ]]; then
-#  STACK="heroku-18"
-# fi
-
-STACK="heroku-18"
+if [[ -z "${STACK}" ]]; then
+  STACK="heroku-18"
+fi
 
 # ensure correct stack
 echo "NOTE: Using [$STACK]" | indent


### PR DESCRIPTION
This reverts commit 4cce688fc853b4ec2c764b0d85278ae4160daba4. The previous commit forced the new stack, but was incorrectly tested against a mixed stack (one based on heroku-18 but purporting to be heroku-16).