### PR TITLE
Update binary tarball for heroku-18

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -191,8 +191,8 @@ CACHE_KEY="$STACK-$R_VERSION-$BUILD_PACK_VERSION.tar.gz"
 if [[ -f "$CACHE_DIR/$CACHE_KEY" ]]; then
 
   echo "Retrieving R binaries from cache" | indent
-  if [ -x "$(command -v pigz)" ] && [ -x "$(command -v pv)" ]; then
-    pv "$CACHE_DIR/$CACHE_KEY" | tar -I pigz -xf - -C .
+  if [ -x "$(command -v pigz)" ]; then
+    tar -I pigz -xf "$CACHE_DIR/$CACHE_KEY" -C .
   else
     tar xzf "$CACHE_DIR/$CACHE_KEY" -C .
   fi
@@ -210,8 +210,8 @@ else
   # curl $R_BINARIES -s -o - | tar xzf - -C .
   # pigz -dc target.tar.gz | tar xf -
   # curl --progress-bar $R_BINARIES | gunzip -f - > "$(basename ${R_BINARIES%.*})"  
-  if [ -x "$(command -v pigz)" ] && [ -x "$(command -v pv)" ]; then
-    curl --progress-bar $R_BINARIES | pv | pigz -dc - > "$(basename ${R_BINARIES%.*})"
+  if [ -x "$(command -v pigz)" ]; then
+    curl --progress-bar $R_BINARIES | pigz -dc - > "$(basename ${R_BINARIES%.*})"
   else
     curl --progress-bar $R_BINARIES | gunzip -f - > "$(basename ${R_BINARIES%.*})"
   fi
@@ -347,8 +347,8 @@ topic "Caching build outputs"
 pushd $BUILD_DIR > /dev/null
 # TODO: have CPUs env var and use with pigz below
 #   eg. tar cf - paths-to-archive | pigz -9 -p 32 > archive.tar.gz
-if [ -x "$(command -v pigz)" ] && [ -x "$(command -v pv)" ]; then
-  tar cf - .root .tools | pv | pigz > "$CACHE_DIR/$CACHE_KEY"
+if [ -x "$(command -v pigz)" ]; then
+  tar cf - .root .tools | pigz > "$CACHE_DIR/$CACHE_KEY"
 else
   tar czf "$CACHE_DIR/$CACHE_KEY" .root .tools
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -191,8 +191,8 @@ CACHE_KEY="$STACK-$R_VERSION-$BUILD_PACK_VERSION.tar.gz"
 if [[ -f "$CACHE_DIR/$CACHE_KEY" ]]; then
 
   echo "Retrieving R binaries from cache" | indent
-  if [ -x "$(command -v pigz)" ]; then
-    tar -I pigz -xf "$CACHE_DIR/$CACHE_KEY" -C .
+  if [ -x "$(command -v pigz)" ] && [ -x "$(command -v pv)" ]; then
+    pv "$CACHE_DIR/$CACHE_KEY" | tar -I pigz -xf - -C .
   else
     tar xzf "$CACHE_DIR/$CACHE_KEY" -C .
   fi
@@ -210,8 +210,8 @@ else
   # curl $R_BINARIES -s -o - | tar xzf - -C .
   # pigz -dc target.tar.gz | tar xf -
   # curl --progress-bar $R_BINARIES | gunzip -f - > "$(basename ${R_BINARIES%.*})"  
-  if [ -x "$(command -v pigz)" ]; then
-    curl --progress-bar $R_BINARIES | pigz -dc - > "$(basename ${R_BINARIES%.*})"
+  if [ -x "$(command -v pigz)" ] && [ -x "$(command -v pv)" ]; then
+    curl --progress-bar $R_BINARIES | pv | pigz -dc - > "$(basename ${R_BINARIES%.*})"
   else
     curl --progress-bar $R_BINARIES | gunzip -f - > "$(basename ${R_BINARIES%.*})"
   fi
@@ -347,8 +347,8 @@ topic "Caching build outputs"
 pushd $BUILD_DIR > /dev/null
 # TODO: have CPUs env var and use with pigz below
 #   eg. tar cf - paths-to-archive | pigz -9 -p 32 > archive.tar.gz
-if [ -x "$(command -v pigz)" ]; then
-  tar cf - .root .tools | pigz > "$CACHE_DIR/$CACHE_KEY"
+if [ -x "$(command -v pigz)" ] && [ -x "$(command -v pv)" ]; then
+  tar cf - .root .tools | pv | pigz > "$CACHE_DIR/$CACHE_KEY"
 else
   tar czf "$CACHE_DIR/$CACHE_KEY" .root .tools
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -334,7 +334,13 @@ patch_chroot "$BUILD_DIR" "/app"
 topic "Caching build outputs"
 
 pushd $BUILD_DIR > /dev/null
-tar czf "$CACHE_DIR/$CACHE_KEY" .root .tools
+# TODO: have CPUs env var and use with pigz below
+#   eg. tar cf - paths-to-archive | pigz -9 -p 32 > archive.tar.gz
+if [ -x "$(command -v pigz)" ]; then
+  tar cf - .root .tools | pigz > "$CACHE_DIR/$CACHE_KEY"
+else
+  tar czf "$CACHE_DIR/$CACHE_KEY" .root .tools
+fi
 popd > /dev/null
 
 #

--- a/bin/compile
+++ b/bin/compile
@@ -179,7 +179,7 @@ BUILD_PACK_VERSION=${BUILD_PACK_VERSION:-latest}
 # build up path to binaries on S3
 R_BINARIES_FILE="R-${R_VERSION}-binaries-${BUILD_PACK_VERSION}.tar.gz"
 #R_BINARIES="https://${S3_BUCKET}.s3.amazonaws.com/${STACK}/$R_BINARIES_FILE"
-R_BINARIES="https://storage.googleapis.com/dashr/$R_BINARIES_FILE"
+R_BINARIES="https://storage.googleapis.com/dashr/heroku-18/$R_BINARIES_FILE"
 
 # vendor R into the slug
 topic "Vendoring R $R_VERSION for $STACK stack ($BUILD_PACK_VERSION)"

--- a/bin/compile
+++ b/bin/compile
@@ -191,7 +191,11 @@ CACHE_KEY="$STACK-$R_VERSION-$BUILD_PACK_VERSION.tar.gz"
 if [[ -f "$CACHE_DIR/$CACHE_KEY" ]]; then
 
   echo "Retrieving R binaries from cache" | indent
-  tar xzf "$CACHE_DIR/$CACHE_KEY" -C .
+  if [ -x "$(command -v pigz)" ]; then
+    tar -I pigz -xf "$CACHE_DIR/$CACHE_KEY" -C .
+  else
+    tar xzf "$CACHE_DIR/$CACHE_KEY" -C .
+  fi
 
 else
 
@@ -204,10 +208,17 @@ else
   # tar xzf "$CACHE_DIR/$R_BINARIES_FILE" -C .
 
   # curl $R_BINARIES -s -o - | tar xzf - -C .
-  curl --progress-bar $R_BINARIES | gunzip -f - > "$(basename ${R_BINARIES%.*})"
+  # pigz -dc target.tar.gz | tar xf -
+  # curl --progress-bar $R_BINARIES | gunzip -f - > "$(basename ${R_BINARIES%.*})"  
+  if [ -x "$(command -v pigz)" ]; then
+    curl --progress-bar $R_BINARIES | pigz -dc - > "$(basename ${R_BINARIES%.*})"
+  else
+    curl --progress-bar $R_BINARIES | gunzip -f - > "$(basename ${R_BINARIES%.*})"
+  fi
+
   echo "R binaries downloaded; extracting ($R_BINARIES_FILE) ..."  | indent
   tar -xf "$(basename ${R_BINARIES%.*})"
-  echo "($(basename ${R_BINARIES%.*})) successfully extracted." | indent
+  echo "$(basename ${R_BINARIES%.*}) successfully extracted." | indent
   echo
 
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -179,7 +179,7 @@ BUILD_PACK_VERSION=${BUILD_PACK_VERSION:-latest}
 # build up path to binaries on S3
 R_BINARIES_FILE="R-${R_VERSION}-binaries-${BUILD_PACK_VERSION}.tar.gz"
 #R_BINARIES="https://${S3_BUCKET}.s3.amazonaws.com/${STACK}/$R_BINARIES_FILE"
-R_BINARIES="https://storage.googleapis.com/dashr/heroku-18/$R_BINARIES_FILE"
+R_BINARIES="https://storage.googleapis.com/dashr/${STACK}/$R_BINARIES_FILE"
 
 # vendor R into the slug
 topic "Vendoring R $R_VERSION for $STACK stack ($BUILD_PACK_VERSION)"


### PR DESCRIPTION
This PR is intended to resolve the following error related to `reqres`, stemming from an old build 
leveraging Plotly's temporary fork of this package (https://github.com/plotly/dashR/pull/122).

```
remote:        Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) :        
remote:        namespace 'reqres' 0.2.2 is already loaded, but >= 0.2.3 is required        
remote:        Calls: <Anonymous> ... namespaceImportFrom -> asNamespace -> loadNamespace        
remote:        Execution halted        
remote:        ERROR: lazy loading failed for package 'dash'        
remote:        * removing '/usr/local/lib/R/site-library/dash'        
remote:        * restoring previous '/usr/local/lib/R/site-library/dash'        
remote:        Error: Failed to install 'dash' from GitHub:        
remote:        (converted from warning) installation of package '/tmp/Rtmp0qIcJZ/file4005fa05649/dash_0.2.0.tar.gz' had non-zero exit status        
```

The tarball has been rebuilt to use R 3.6.2 and the current CRAN version (0.2.3) of `reqres`.