### PR TITLE
Improvements to further streamline deployments to Dash Enterprise

### DIFF
--- a/bin/Rprofile.site
+++ b/bin/Rprofile.site
@@ -4,8 +4,14 @@
 # print("Fixing normalizePath for symlinked /app")
 
 # HACK normalizePath method, so that it works for /app symlink
-Sys.setenv(DASH_PORT="5000")
-Sys.setenv(DASH_HOST="0.0.0.0")
+if (Sys.getenv("DASH_PORT") == "") {
+  Sys.setenv(DASH_PORT="5000")
+}
+
+if (Sys.getenv("DASH_HOST") == "") {
+  Sys.setenv(DASH_HOST="0.0.0.0")
+}
+
 oldnormalizePath <- base::normalizePath
 newnormalizePath <- function(path, winslash="\\", mustWork=NA) {
   # override mustWork to FALSE

--- a/bin/Rprofile.site
+++ b/bin/Rprofile.site
@@ -4,6 +4,8 @@
 # print("Fixing normalizePath for symlinked /app")
 
 # HACK normalizePath method, so that it works for /app symlink
+Sys.setenv(DASH_PORT="5000")
+Sys.setenv(DASH_HOST="0.0.0.0")
 oldnormalizePath <- base::normalizePath
 newnormalizePath <- function(path, winslash="\\", mustWork=NA) {
   # override mustWork to FALSE

--- a/bin/Rprofile.site
+++ b/bin/Rprofile.site
@@ -3,15 +3,16 @@
 
 # print("Fixing normalizePath for symlinked /app")
 
+# Set environment variables if unset
+if (Sys.getenv("PORT") == "") {
+  Sys.setenv(PORT="5000")
+}
+
+if (Sys.getenv("HOST") == "") {
+  Sys.setenv(HOST="0.0.0.0")
+}
+
 # HACK normalizePath method, so that it works for /app symlink
-if (Sys.getenv("DASH_PORT") == "") {
-  Sys.setenv(DASH_PORT="5000")
-}
-
-if (Sys.getenv("DASH_HOST") == "") {
-  Sys.setenv(DASH_HOST="0.0.0.0")
-}
-
 oldnormalizePath <- base::normalizePath
 newnormalizePath <- function(path, winslash="\\", mustWork=NA) {
   # override mustWork to FALSE

--- a/bin/compile
+++ b/bin/compile
@@ -156,7 +156,7 @@ if [[ -f "$BUILD_DIR/.r-version" ]]; then
   R_VERSION=$(read_var "$BUILD_DIR/.r-version")
   echo "NOTE: Using R version override [$R_VERSION]" | indent
 else
-  R_VERSION="3.6.1"
+  R_VERSION="3.6.2"
 fi
 
 # environment
@@ -177,7 +177,7 @@ CRAN_MIRROR=${CRAN_MIRROR:-"https://cloud.r-project.org"}
 BUILD_PACK_VERSION=${BUILD_PACK_VERSION:-latest}
 
 # build up path to binaries on S3
-R_BINARIES_FILE="R-${R_VERSION}-binaries-${BUILD_PACK_VERSION}.tar.gz"
+R_BINARIES_FILE="R-${R_VERSION}-binaries-${BUILD_PACK_VERSION}-rpk.tar.gz"
 #R_BINARIES="https://${S3_BUCKET}.s3.amazonaws.com/${STACK}/$R_BINARIES_FILE"
 R_BINARIES="https://storage.googleapis.com/dashr/${STACK}/$R_BINARIES_FILE"
 

--- a/bin/compile
+++ b/bin/compile
@@ -255,16 +255,16 @@ fakechroot fakeroot chroot $CHROOT_DIR \
 popd > /dev/null
 
 # Aptfile?
-if [[ -f "$BUILD_DIR/Aptfile" ]]; then
+if [[ -f "$BUILD_DIR/apt-packages" ]]; then
 
-  topic "Installing binary dependencies from Aptfile"
+  topic "Installing binary dependencies from apt-packages"
 
   # TODO: add support for deb files
 
   PACKAGES=""
   while IFS='' read -r PACKAGE || [[ -n "$PACKAGE" ]]; do
     PACKAGES="$PACKAGES $PACKAGE"
-  done < "$BUILD_DIR/Aptfile"
+  done < "$BUILD_DIR/apt-packages"
 
   fakechroot fakeroot chroot $CHROOT_DIR \
     apt-get update > /dev/null

--- a/bin/compile
+++ b/bin/compile
@@ -177,7 +177,7 @@ CRAN_MIRROR=${CRAN_MIRROR:-"https://cloud.r-project.org"}
 BUILD_PACK_VERSION=${BUILD_PACK_VERSION:-latest}
 
 # build up path to binaries on S3
-R_BINARIES_FILE="R-${R_VERSION}-binaries-${BUILD_PACK_VERSION}-rpk.tar.gz"
+R_BINARIES_FILE="R-${R_VERSION}-binaries-${BUILD_PACK_VERSION}.tar.gz"
 #R_BINARIES="https://${S3_BUCKET}.s3.amazonaws.com/${STACK}/$R_BINARIES_FILE"
 R_BINARIES="https://storage.googleapis.com/dashr/${STACK}/$R_BINARIES_FILE"
 

--- a/bin/detect
+++ b/bin/detect
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # bin/detect <build-dir>
 
-# look for init.r or init.R or run.R
-if [ -f $1/run.R ] || [ -f $1/app.R ]; then
+# look for init.r / init.R / run.r / run.R / app.r / app.R
+if [ -f $1/run.R ] || [ -f $1/app.R ] || [ -f $1/run.r ] || [ -f $1/app.r ]; then
   echo "Dash for R" && exit 0
 elif [ -f $1/init.r ] || [ -f $1/init.R ]; then
   echo "R Console" && exit 0

--- a/bin/detect
+++ b/bin/detect
@@ -2,8 +2,8 @@
 # bin/detect <build-dir>
 
 # look for init.r or init.R or run.R
-if [ -f $1/run.R ]; then
-  echo "DashR" && exit 0
+if [ -f $1/run.R ] || [ -f $1/app.R ]; then
+  echo "Dash for R" && exit 0
 elif [ -f $1/init.r ] || [ -f $1/init.R ]; then
   echo "R Console" && exit 0
 else

--- a/bin/release
+++ b/bin/release
@@ -1,15 +1,40 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
-if [ -f $1/run.R ] || [ -f $1/app.R ] || [ -f $1/run.r ] || [ -f $1/app.r ]; then
-
-	# Dash for R app
-	cat <<EOF
+if [ -f "$1/run.R" ]; then
+        # Dash for R app
+        cat <<EOF
 ---
 # Dash for R 
 default_process_types:
-  console: fakechroot fakeroot chroot /app/.root /bin/bash
   web: fakechroot fakeroot chroot /app/.root /bin/sh -c 'cd /app && /usr/bin/R -f /app/run.R --gui-none --no-save'
+EOF
+
+elif [ -f "$1/run.r" ]; then
+        # Dash for R app
+        cat <<EOF
+---
+# Dash for R 
+default_process_types:
+  web: fakechroot fakeroot chroot /app/.root /bin/sh -c 'cd /app && /usr/bin/R -f /app/run.r --gui-none --no-save'
+EOF
+
+elif [ -f "$1/app.R" ]; then
+        # Dash for R app
+        cat <<EOF
+---
+# Dash for R 
+default_process_types:
+  web: fakechroot fakeroot chroot /app/.root /bin/sh -c 'cd /app && /usr/bin/R -f /app/app.R --gui-none --no-save'
+EOF
+
+elif [ -f "$1/app.r" ]; then
+        # Dash for R app
+        cat <<EOF
+---
+# Dash for R 
+default_process_types:
+  web: fakechroot fakeroot chroot /app/.root /bin/sh -c 'cd /app && /usr/bin/R -f /app/app.r --gui-none --no-save'
 EOF
 
 else

--- a/bin/release
+++ b/bin/release
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
-if [ -f "$1/run.R" ]; then
+if [ -f $1/run.R ] || [ -f $1/app.R ] || [ -f $1/run.r ] || [ -f $1/app.r ]; then
 
-	# shiny app
+	# Dash for R app
 	cat <<EOF
 ---
-# DashR 
+# Dash for R 
 default_process_types:
   console: fakechroot fakeroot chroot /app/.root /bin/bash
   web: fakechroot fakeroot chroot /app/.root /bin/sh -c 'cd /app && /usr/bin/R -f /app/run.R --gui-none --no-save'

--- a/bin/renv.sh
+++ b/bin/renv.sh
@@ -5,4 +5,6 @@ CHROOT_DIR="$APP_DIR/.root"
 TOOLS_DIR="$APP_DIR/.tools"
 FAKEROOT_DIR="$TOOLS_DIR/fakeroot"
 FAKECHROOT_DIR="$TOOLS_DIR/fakechroot"
+DASH_PORT=5000
+DASH_HOST="0.0.0.0"
 export PATH="$FAKEROOT_DIR/bin:$FAKECHROOT_DIR/sbin:$FAKECHROOT_DIR/bin:./bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"

--- a/bin/renv.sh
+++ b/bin/renv.sh
@@ -5,6 +5,4 @@ CHROOT_DIR="$APP_DIR/.root"
 TOOLS_DIR="$APP_DIR/.tools"
 FAKEROOT_DIR="$TOOLS_DIR/fakeroot"
 FAKECHROOT_DIR="$TOOLS_DIR/fakechroot"
-DASH_PORT=5000
-DASH_HOST="0.0.0.0"
 export PATH="$FAKEROOT_DIR/bin:$FAKECHROOT_DIR/sbin:$FAKECHROOT_DIR/bin:./bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"


### PR DESCRIPTION
This PR proposes to autoset `DASH_HOST` and `DASH_PORT` such that Dash for R applications may be deployed to Dash Enterprise without specifying either, e.g.

`app$run_server()`

instead of

`app$run_server(host = "127.0.0.1", port = "5000")`

Additionally, a minor edit is contributed that autodetects both `run.R` and `app.R` when deploying.