### PR TITLE
Update R to v3.6.3 and remove dash packages from buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -156,7 +156,7 @@ if [[ -f "$BUILD_DIR/.r-version" ]]; then
   R_VERSION=$(read_var "$BUILD_DIR/.r-version")
   echo "NOTE: Using R version override [$R_VERSION]" | indent
 else
-  R_VERSION="3.6.2"
+  R_VERSION="3.6.3"
 fi
 
 # environment


### PR DESCRIPTION
This PR proposes to update the R version within the buildpack to v3.6.3 from 3.6.2, and removes `dash` to avoid version incompatibility issues when installing `dash` via CRAN.

We may also consider modifying this line to read `/app`, since it seems unlikely that `app` will be a subfolder of any directory other than `/`:

https://github.com/plotly/heroku-buildpack-r/blob/f04b8f8d05f42b7ce8b453e3d41d78e330ba9b75/bin/environ/Rprofile.site#L23